### PR TITLE
🔧fix: add app name on error log report

### DIFF
--- a/src/dymo-api.ts
+++ b/src/dymo-api.ts
@@ -134,7 +134,7 @@ class DymoAPI {
         try {
             await this.getTokens();
         } catch (error: any) {
-            console.error(`Error initializing tokens: ${error.message}`);
+            console.error(`[${config.lib.name}] Error initializing tokens: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
# Title
Include application name in error log report

## Description:
This PR enhances the error logging functionality by including the application name in the log report. This update improves the traceability of errors, especially in multi-application environments.

## Changes
- The application name is now appended to all error log entries, providing clear context on which application generated the error.

## How to Test It:
- Trigger error logging in the application.
- Verify that the log entries now include the application name at the beginning.
- Ensure that the application name is correct and consistent across all log entries